### PR TITLE
Add LinkedIn profile link

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { getSortedPostsData } from "@/lib/posts";
-import { ArrowRight, Github, Twitter } from "lucide-react";
+import { ArrowRight, Github, Linkedin, Twitter } from "lucide-react";
 
 import { ProjectGrid } from "@/components/ProjectGrid";
 import { formatDate } from "@/lib/utils";
@@ -35,6 +35,15 @@ export default function Home() {
           >
             <Twitter size={18} />
             <span>Twitter</span>
+          </a>
+          <a
+            href="https://www.linkedin.com/in/jetsemrick/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 text-sm font-medium text-foreground/60 transition-colors hover:text-foreground"
+          >
+            <Linkedin size={18} />
+            <span>LinkedIn</span>
           </a>
         </div>
       </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a LinkedIn profile link (https://www.linkedin.com/in/jetsemrick/) alongside the existing Twitter and GitHub links on the homepage. Uses the Linkedin icon from lucide-react for consistency with the other social links.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2fd86d1-3c19-40e6-baa7-631ac2584a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2fd86d1-3c19-40e6-baa7-631ac2584a24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

